### PR TITLE
Correct misspelling on the word "license"

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ TODO
 2. Fix typo (may need your help)
 3. Border issue
     
-Lisence
+License
 =======
 > Permission is hereby granted, free of charge, to any person obtaining a copy
 > of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The title said "Lisence" and the correct word is "license".
Sorry it just bugged me a lot :(

Just in case I google'd it http://en.wikipedia.org/wiki/License english is not my native language so I was afraid of being wrong.

BTW awesome work!
