### PR TITLE
Better demo GIF.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-![image](https://raw.githubusercontent.com/mrcrow/MRoundedButton/master/present.gif)
-
-> Powered by [Gifrocket](http://www.gifrocket.com)
+![image](present.gif)
 
 MRoundedButton
 ==============


### PR DESCRIPTION
I redid the screen recording on my computer and exported the gif from Photoshop. The resulting GIF was 22 MB, but ImageOptim was apparently able to get the size down to 6.2 MB without loss of limb. As a bonus, it now has an Apple-approved “9:41 AM” clock, suitable for framing.
